### PR TITLE
Adding definition of question settings, updating license description …

### DIFF
--- a/exercise.schema.json
+++ b/exercise.schema.json
@@ -95,9 +95,9 @@
         },
         "attempt_settings": {
           "description": "Settings which apply to a specific attempt. The index of the array is used as the number of the attempt the setting applies to. If no specific settings are given the value will be the default of the property",
-          "type": "array",
-          "items": {
-            "type": "object", "properties": {
+          "type": "object",
+          "patternProperties" : {
+            "^[0-9]$": {
               "percentage_of_full_points": {
                 "description": "The percentage with which the maximum number of points for this question is multiplied if the user answers the question correctly in this attempt",
                 "type": "number",

--- a/exercise.schema.json
+++ b/exercise.schema.json
@@ -75,11 +75,50 @@
           "description": "List of answer fields which can be used within this question",
           "type": "array",
           "items": {"$ref": "#/definitions/answer_field"}
+        },
+        "settings": {
+          "description": "Settings which influence the way the question is to be consumed by the player",
+          "$ref": "#/definitions/question_settings"
         }
       },
       "required": [
         "id", "type", "question", "answers"
       ]
+    },
+    "question_settings" : {
+      "type": "object",
+      "properties": {
+        "max_attempts": {
+          "description": "The number of attempts a user has for answering the question correctly",
+          "type": "number",
+          "default": 3
+        },
+        "attempt_settings": {
+          "description": "Settings which apply to a specific attempt. The index of the array is used as the number of the attempt the setting applies to. If no specific settings are given the value will be the default of the property",
+          "type": "array",
+          "items": {
+            "type": "object", "properties": {
+              "percentage_of_full_points": {
+                "description": "The percentage with which the maximum number of points for this question is multiplied if the user answers the question correctly in this attempt",
+                "type": "number",
+                "default": 0
+              }
+            }
+          },
+          "default": [
+            { "percentage_of_full_points": 100}
+          ]
+        },
+        "feedback_at_incorrect_end_state": {
+          "description": "The type of feedback which should be shown when the user has used `max_attempts` without a correct answer. This can either be the feedback for the given answer, or both the correct answer and the contents of the `feedback_correct` field ('correct_answer_and_detailed_solution')",
+          "type": "string",
+          "enum": [
+            "given_answer_feedback", "correct_answer_and_detailed_solution"
+          ],
+          "default": "correct_answer_and_detailed_solution"
+        }
+      },
+      "required": []
     },
     "answer": {
       "type": "object",
@@ -284,7 +323,7 @@
       "type": "object",
       "properties": {
         "name": { "type": "string" },
-        "description": { "type": "string" },
+        "description": { "$ref": "#/definitions/rich_content" },
         "value": { "type": "string" },
         "link": { "type": "string" }
       },

--- a/exercise.schema.json
+++ b/exercise.schema.json
@@ -94,10 +94,10 @@
           "default": 3
         },
         "attempt_settings": {
-          "description": "Settings which apply to a specific attempt. The index of the array is used as the number of the attempt the setting applies to. If no specific settings are given the value will be the default of the property",
+          "description": "Settings which apply to a specific attempt. The settings for the first attempt are specified in the object under the key '1'. If no specific settings are given for an attempt the value will be the default of the property",
           "type": "object",
           "patternProperties" : {
-            "^[0-9]$": {
+            "^[1-9]$": {
               "percentage_of_full_points": {
                 "description": "The percentage with which the maximum number of points for this question is multiplied if the user answers the question correctly in this attempt",
                 "type": "number",
@@ -106,7 +106,7 @@
             }
           },
           "default": [
-            { "percentage_of_full_points": 100}
+            { "1": { "percentage_of_full_points": 100 }}
           ]
         },
         "feedback_at_incorrect_end_state": {


### PR DESCRIPTION
This updates the format with two fixes:

- we updated the type of the license description to rich content as it can contain links
- we added the `settings` property to questions to facilitate the export of newly added settings